### PR TITLE
Adding support for auto-adding remote related files to .gitignore

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+1.2.5
+-----
+* Support for adding .remote related files to .gitignore
+
 1.2.4
 -----
 * More robust parameter parsing

--- a/bin/remote-init
+++ b/bin/remote-init
@@ -18,3 +18,18 @@ fi
 ssh -tqK $remote_host "source ~/.bash_profile; mkdir -p $remote_directory"
 echo $remote_host:$remote_directory > .remote
 echo "Created remote directory at $remote_host:$remote_directory"
+
+
+# help out with .gitignore if we are in a git repository
+if [ -d ".git" ]; then
+  # make sure we don't keep adding to .gitignore
+  git_ignore_file_name=.gitignore
+  grep ".remote\*" $git_ignore_file_name > /dev/null 2>&1
+  if [ "$?" != 0 ]; then
+    remote_git_ignore_entry=.remote*
+    echo "\n$remote_git_ignore_entry" >> "$git_ignore_file_name"
+    echo "Added $remote_git_ignore_entry to $git_ignore_file_name"
+  fi
+fi
+
+# TODO: help out with svn ignore too


### PR DESCRIPTION
Tested with
- no .gitignore file
- .gitignore file with and without new line at end of file
- .gitignore file with similar entries (like ".remotetralala*", ".remote*tralala" and ".remotetralala")