### PR TITLE
Added indentation for ignores in remote-explain

### DIFF
--- a/bin/remote-explain
+++ b/bin/remote-explain
@@ -14,8 +14,7 @@ remote_command_dir=`get_remote_command_directory`
 if [ -f "$local_dir/.remoteignore" ];
 then
   echo "Remote ignores: hosted at $local_dir/.remoteignore"
-  cat $local_dir/.remoteignore
-  echo "------- ignores end>"
+  cat $local_dir/.remoteignore | sed 's/^/  - /'
 else
   echo "Remote ignores: none"
 fi


### PR DESCRIPTION
This reformats the output of the remote ignores to add some indentation, removing the need for the closing bracket. Example output:
```
Remote ignores: hosted at /Users/jbencina/repos/myproject/.remoteignore
  - bundle/cache
  - build
  - bundle/cache
  - build
```