### PR TITLE
Add support for reading RSHELL and default remoteignore from config

### DIFF
--- a/bin/remote-init
+++ b/bin/remote-init
@@ -33,5 +33,29 @@ else
       echo "Added $remote_git_ignore_entry to $git_ignore_file_name"
     fi
   fi
+  # TODO: help out with svn ignore too
+
+  # check if there is a config directory
+  xdg_config_home="${XDG_CONFIG_HOME:-$HOME/.config}"
+  config_dir="$xdg_config_home/remote"
+  remote_ignore="$config_dir/remoteignore"
+  cfg_file="$config_dir/remote.cfg"
+  if [ -s "$remote_ignore" ]; then
+     touch .remoteignore
+     while read -r line
+     do
+       printf "$line\n" >> .remoteignore
+       echo "Added $line to .remoteignore"
+     done < $remote_ignore
+  fi
+  # check if RSHELL is set in remote.cfg
+  if [ -s "$cfg_file" ]; then
+    rshell=$(grep RSHELL=.* $cfg_file)
+    if [ "$?" != 0 ]; then
+      echo "No RSHELL setting found in remote.cfg; skipping."
+    else
+      echo "Setting $rshell for this remote"
+      sed -i "" "s/\$/ $rshell/" .remote
+    fi
+  fi
 fi
-# TODO: help out with svn ignore too


### PR DESCRIPTION
This adds support for populating `RSHELL` during `remote-init` (but not `remote-add`) based on a config file as well as populating `.remoteignore` based on a default file. 

The RSHELL variable is set in `$XDG_CONFIG_DIR/remote/remote.cfg` and the contents of `$XDG_CONFIG_DIR/remote/remoteignore` are copied into `.remoteignore`.