### PR TITLE
Create github action to publish a release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+on:
+    push:
+      tags:
+        - v*
+    pull_request:
+      branches:
+        - master
+
+name: Create Release
+
+jobs:
+    bash-tgz:
+      name: Build bash implementation
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out code
+          uses: actions/checkout@v2
+        - name: Create tgz archive
+          run: |
+            mkdir remote
+            cp -r bin remote
+            tar -cvzf remote-sh.tgz remote
+        - name: Upload release artifact
+          uses: actions/upload-artifact@v2
+          with:
+            name: remote-sh
+            path: remote-sh.tgz
+
+    release:
+      name: Publish release
+      runs-on: ubuntu-latest
+      needs:
+        - bash-tgz
+      if: github.event_name == 'push' && startsWith(github.ref, 'v')
+      steps:
+        - name: Determine release version
+          id: release_info
+          env:
+            TAG: ${{ github.ref }}
+          run: echo "::set-output name=version::${TAG:1}"
+        - name: Fetch bash artifact
+          uses: actions/download-artifact@v2
+          with:
+            name: remote-sh
+        - name: Show release artifacts
+          run: ls -la release
+        - name: Create draft release
+          id: create_release
+          uses: actions/create-release@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            tag_name: ${{ github.ref }}
+            release_name: ${{ github.ref }}
+            draft: true
+            prerelease: true
+        - name: Upload bash artifact
+          uses: actions/upload-release-asset@v1
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }}
+            asset_path: ./remote-sh.tgz
+            asset_name: remote-${{ steps.release_info.outputs.version }}-sh.tgz
+            asset_content_type: applictaion/gzip

--- a/README.md
+++ b/README.md
@@ -18,8 +18,3 @@ Executables and purpose
 * remote-quick: execute a command remotely, without syncing the trees
 * remote-add: add another remote host to the mirror list
 * mremote: execute a remote command on all the hosts, after first syncing the local tree with the remote trees
-
-Build a package
----------------
-./build
-

--- a/build
+++ b/build
@@ -1,7 +1,0 @@
-#!/bin/bash
-version=`head -n 1 CHANGELOG`
-echo $version
-mkdir remote
-cp -r bin remote/
-tar -cvzf remote-$version.tgz remote
-rm -rf remote


### PR DESCRIPTION
This RB introduces the GitHub action that will do two things:
- create an archive with sources on each pull request
- publish this archive as a part of github release draft each time something is pushed to master with a tag looking like `v1.3.5`

This workflow might be easily extended to publish both sh and python version to make the transition graceful.

I also removed the build script because it duplicates the workflow now.

Don't know how to test these actions, though