### PR TITLE
Implement most of entry points in Python

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,43 @@
+name: Python Code Quality
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  check:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip setuptools wheel
+        pip install -r test_requirements.txt
+    - name: Lint with flake8
+      run: |
+        flake8 src
+    - name: Lint with mypy
+      run: |
+        mypy -p remote
+    - name: Lint with black
+      run: |
+        black --check -l 120 src
+    - name: Lint with isort
+      run: |
+        isort -rc --check-only src
+    - name: Test with pytest
+      run: |
+        # replace it with pytest once we add some tests
+        echo ok

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
       runs-on: ubuntu-latest
       needs:
         - bash-tgz
-      if: github.event_name == 'push' && startsWith(github.ref, 'v')
+      if: github.event_name == 'push'
       steps:
         - name: Determine release version
           id: release_info

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+env
+__pycache__
+*.pyc
+*.egg-info
+.*_cache
+.remote*
+dist
+build

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,47 @@
+{
+    "python.pythonPath": "${workspaceFolder}/env/bin/python",
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.nosetestsEnabled": false,
+    "python.testing.pytestArgs": [
+        "--no-cov",
+        "${workspaceFolder}/test"
+    ],
+    "python.testing.cwd": "${workspaceFolder}/.",
+    "python.linting.enabled": true,
+    "python.linting.lintOnSave": true,
+    "python.linting.pylintEnabled": false,
+    "python.linting.flake8Enabled": true,
+    "python.linting.flake8Args": [
+        "--config",
+        "${workspaceFolder}/setup.cfg"
+    ],
+    "python.linting.mypyEnabled": true,
+    "python.linting.mypyArgs": [
+        "--ignore-missing-imports",
+        "--config-file",
+        "${workspaceFolder}/setup.cfg"
+    ],
+    "editor.formatOnSave": true,
+    "files.trimTrailingWhitespace": true,
+    "python.formatting.provider": "black",
+    "python.formatting.blackArgs": [
+        "-l",
+        "120"
+    ],
+    "python.sortImports.args": [
+        "-rc",
+        "--settings-path",
+        "${workspaceFolder}/setup.cfg"
+    ],
+    "files.exclude": {
+        "build": true,
+        "dist": true,
+        "**/*.egg-info": true,
+        "**/__pycache__": true,
+        "**/.*_cache": true,
+        ".*_cache": true,
+        ".git": true,
+        ".remote*": true
+    }
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,25 @@
+BSD 2-CLAUSE LICENSE
+
+Copyright 2012 Shirshanka Das.
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,19 @@
+[flake8]
+max-line-length = 130
+max-complexity = 15
+
+[mypy]
+mypy_path = src
+namespace_packages = true
+strict_optional = yes
+disallow_untyped_defs = no
+
+[isort]
+line_length = 120
+indent='    '
+multi_line_output = 3
+lines_between_types = 1
+include_trailing_comma = true
+use_parentheses = true
+not_skip = __init__.py
+sections = FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+import os
+import setuptools
+
+
+def get_version():
+    root = os.path.dirname(__file__)
+    changelog = os.path.join(root, "CHANGELOG")
+    with open(changelog) as f:
+        return f.readline().strip()
+
+
+setuptools.setup(
+    name="remote",
+    version=get_version(),
+    url="https://github.com/shirshanka/remote",
+    author="Shirshanka Das",
+    package_dir={"": "src"},
+    packages=setuptools.find_namespace_packages(where="src"),
+    entry_points={
+        "console_scripts": [
+            "remote = remote.entrypoints:remote",
+            "remote-add = remote.entrypoints:remote_add",
+            "remote-delete = remote.entrypoints:remote_delete",
+            "remote-explain = remote.entrypoints:remote_explain",
+            "remote-host = remote.entrypoints:remote_host",
+            "remote-ignore = remote.entrypoints:remote_ignore",
+            "remote-init = remote.entrypoints:remote_init",
+            "remote-pull = remote.entrypoints:remote_pull",
+            "remote-push = remote.entrypoints:remote_push",
+            "remote-quick = remote.entrypoints:remote_quick",
+            "remote-set = remote.entrypoints:remote_set",
+            "mremote = remote.entrypoints:mremote",
+            "mremote-push = remote.entrypoints:mremote_push",
+        ],
+    },
+)

--- a/src/remote/configuration/__init__.py
+++ b/src/remote/configuration/__init__.py
@@ -1,0 +1,98 @@
+import hashlib
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+
+@dataclass
+class RemoteConfig:
+    """Single remote connection decription"""
+
+    # remote machine's hostname
+    host: str
+    # relative path to the working directory on remote machine starting from user home dir
+    directory: Path
+    # a shell to use on remote machine
+    shell: str
+    # shell options to use on remote machine
+    shell_options: str
+
+
+@dataclass
+class SyncIgnores:
+    """Patterns used to ignore files when syncing with remote location"""
+
+    # patterns to ignore while pulling from remote
+    pull: List[str]
+    # patterns to ignore while pushing from local
+    push: List[str]
+    # patterns to ignore while transferring files in both directions
+    both: List[str]
+
+    def __post_init__(self):
+        self.pull = sorted(set(self.pull))
+        self.push = sorted(set(self.push))
+        self.both = sorted(set(self.both))
+
+    def compile_push_ignores(self):
+        result = set()
+        result.update(self.push)
+        result.update(self.both)
+        return sorted(result)
+
+    def compile_pull_ignores(self):
+        result = set()
+        result.update(self.pull)
+        result.update(self.both)
+        return sorted(result)
+
+    def add_ignores(self, ignores: List[str]):
+        new_ignores = set()
+        new_ignores.update(ignores)
+        new_ignores.update(self.both)
+        self.both = sorted(new_ignores)
+
+    def is_empty(self):
+        return not (self.pull or self.push or self.both)
+
+    @classmethod
+    def new(cls) -> "SyncIgnores":
+        return cls([], [], [])
+
+
+@dataclass
+class WorkspaceConfig:
+    """Complete remote workspace config"""
+
+    # absolute path to the workspace root
+    root: Path
+    # remote host connection options that can be used in this workspace
+    configurations: List[RemoteConfig]
+    # index of default remote host connection
+    default_configuration: int
+    # patterns to ignore while syncing the workspace
+    ignores: SyncIgnores
+
+    @classmethod
+    def empty(cls) -> "WorkspaceConfig":
+        return cls(root=Path.cwd(), configurations=[], default_configuration=0, ignores=SyncIgnores.new())
+
+    def generate_remote_directory_name(self) -> str:
+        md5 = hashlib.md5(str(self.root).encode()).hexdigest()
+        return f".remotes/{self.root.name}_{md5[:8]}"
+
+    def add_remote_host(
+        self, host, directory: Optional[str] = None, shell: Optional[str] = None, shell_options: Optional[str] = None
+    ) -> Tuple[bool, int]:
+        remote_config = RemoteConfig(
+            host=host,
+            directory=Path(directory or self.generate_remote_directory_name()),
+            shell=shell or "sh",
+            shell_options=shell_options or "",
+        )
+        for num, cfg in enumerate(self.configurations):
+            if cfg.host == remote_config.host and cfg.directory == remote_config.directory:
+                return False, num
+        self.configurations.append(remote_config)
+        return True, len(self.configurations) - 1

--- a/src/remote/configuration/classic.py
+++ b/src/remote/configuration/classic.py
@@ -1,0 +1,182 @@
+"""
+A module that contains utility functions to load the 'classical' workspace configuration.
+This configuration may have three meaningful files:
+.remote (required) - information about the connection options
+.remoteindex (optional) - information about which connection from options above to use
+.remoteignore (optional) - information about files that should be ignore when syncing files
+"""
+import os
+import re
+
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from remote.exceptions import ConfigurationError
+
+from . import RemoteConfig, SyncIgnores, WorkspaceConfig
+
+CONFIG_FILE_NAME = ".remote"
+INDEX_FILE_NAME = ".remoteindex"
+IGNORE_FILE_NAME = ".remoteignore"
+IGNORE_SECTION_REGEX = re.compile(r"^(push|pull|both)\s*:$")
+BASE_IGNORES = (CONFIG_FILE_NAME, INDEX_FILE_NAME, IGNORE_FILE_NAME)
+
+
+def _resolve_workspace_root(working_dir: Path) -> Optional[Path]:
+    """Find and return the directory in this tree that has remote-ing set up"""
+    possible_directory = working_dir
+    root = Path("/")
+    while not possible_directory == root:
+        cfg_file = possible_directory / CONFIG_FILE_NAME
+        if cfg_file.is_file():
+            return possible_directory
+        possible_directory = possible_directory.parent
+
+    return None
+
+
+def _load_configruations(workspace_root: Path) -> List[RemoteConfig]:
+    config_file = workspace_root / CONFIG_FILE_NAME
+
+    configurations = []
+    for line in config_file.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+
+        # The line should look like this:
+        # sdas-ld2:.remotes/814f27f15f4e7a0842cada353dfc765a RSHELL=zsh
+        entry, *env_items = line.split()
+        env: Dict[str, str] = dict((item.split("=") for item in env_items))  # type: ignore
+        # TODO: these shell types are not used in new implementation, need to remove them
+        shell = env.pop("RSHELL", "sh")
+        shell_options = env.pop("RSHELL_OPTS", "")
+        if env:
+            raise ConfigurationError(
+                f"Config line {line} contains unexpected env variables: {env}. Only RSHELL and RSHELL_OPTS can be used"
+            )
+        host, directory = entry.split(":")
+        rc = RemoteConfig(host=host, directory=Path(directory), shell=shell, shell_options=shell_options)
+        configurations.append(rc)
+
+    return configurations
+
+
+def _load_default_configuration_num(workspace_root: Path) -> int:
+    # If REMOTE_HOST_INDEX is set, that overrides settings in .remoteindex
+    env_index = os.environ.get("REMOTE_HOST_INDEX")
+    if env_index:
+        return int(env_index)
+
+    index_file = workspace_root / INDEX_FILE_NAME
+    if not index_file.exists():
+        return 0
+    # Configuration uses 1-base index and we need to have 0-based
+    return int(index_file.read_text().strip()) - 1
+
+
+def _postprocess(ignores):
+    pull = ignores.pop("pull", [])
+    push = ignores.pop("push", [])
+    both = ignores.pop("both", [])
+    if ignores:
+        raise ConfigurationError(
+            f"{IGNORE_FILE_NAME} file has unexpected sections: {', '.join(ignores.keys())}. Please remove them"
+        )
+    return SyncIgnores(pull=pull, push=push, both=both)
+
+
+def _load_ignores(workspace_root: Path) -> SyncIgnores:
+    ignores: Dict[str, List[str]] = defaultdict(list)
+    ignores["both"].extend(BASE_IGNORES)
+
+    ignore_file = workspace_root / IGNORE_FILE_NAME
+    if not ignore_file.exists():
+        return _postprocess(ignores)
+
+    active_section = "both"
+    is_new_format = None
+    for line in ignore_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        matcher = IGNORE_SECTION_REGEX.match(line)
+        if matcher is None:
+            if is_new_format is None:
+                is_new_format = False
+            ignores[active_section].append(line)
+        else:
+            if is_new_format is None:
+                is_new_format = True
+            elif not is_new_format:
+                raise ConfigurationError(
+                    f"Few ignore patters were listed in {IGNORE_FILE_NAME} before the first section {matcher.group(1)} appeared. "
+                    "Please list all ignored files after a section declataion if you use new ignore format"
+                )
+            active_section = matcher.group(1)
+
+    return _postprocess(ignores)
+
+
+def load_workspace_config(working_dir: Path) -> WorkspaceConfig:
+    """Load the classic workspace config for the provided working directory"""
+    workspace_root = _resolve_workspace_root(working_dir)
+    if workspace_root is None:
+        raise ConfigurationError(f"Cannot resolve the remote workspace in {working_dir}")
+    configurations = _load_configruations(workspace_root)
+    configuration_index = _load_default_configuration_num(workspace_root)
+    if configuration_index > len(configurations) - 1:
+        raise ConfigurationError(
+            f"Configuration #{configuration_index + 1} requested but there are only {len(configurations)} declared"
+        )
+    ignores = _load_ignores(workspace_root)
+
+    return WorkspaceConfig(
+        root=workspace_root, configurations=configurations, default_configuration=configuration_index, ignores=ignores,
+    )
+
+
+def save_general_config(config_file: Path, configurations: List[RemoteConfig]):
+    with config_file.open("w") as f:
+        for item in configurations:
+            f.write(f"{item.host}:{item.directory}")
+            if item.shell != "sh":
+                f.write(f" RSHELL={item.shell}")
+            if item.shell_options:
+                f.write(f" RSHELL_OPTS={item.shell_options}")
+            f.write("\n")
+
+
+def save_ignores(config_file: Path, ignores: SyncIgnores):
+    ignores.both.extend(BASE_IGNORES)
+
+    if ignores.is_empty():
+        if config_file.exists():
+            config_file.unlink()
+        return
+
+    with config_file.open("w") as f:
+        for name in ("both", "push", "pull"):
+            f.write(f"{name}:\n")
+            for item in sorted(set(getattr(ignores, name))):
+                f.write(f"{item}\n")
+
+
+def save_index(config_file: Path, index: int):
+    if index == 0:
+        # We delete file when index is default
+        if config_file.exists():
+            config_file.unlink()
+    else:
+        config_file.write_text(f"{index + 1}\n")
+
+
+def save_config(config: WorkspaceConfig):
+    """Save the classic workspace config into workspace's root.
+    This method might delete config files if they contain only default values
+    """
+    save_general_config(config.root / CONFIG_FILE_NAME, config.configurations)
+    save_ignores(config.root / IGNORE_FILE_NAME, config.ignores)
+    save_index(config.root / INDEX_FILE_NAME, config.default_configuration)

--- a/src/remote/configuration/discovery.py
+++ b/src/remote/configuration/discovery.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from . import WorkspaceConfig
+from .classic import load_workspace_config
+
+
+def load_cwd_workspace_config() -> WorkspaceConfig:
+    """Determine current working directory's workspace config type and load it
+
+    Supports only classical config layout now, but will be extended once the new type is added
+    """
+    working_dir = Path.cwd()
+    return load_workspace_config(working_dir)

--- a/src/remote/entrypoints.py
+++ b/src/remote/entrypoints.py
@@ -1,0 +1,234 @@
+import argparse
+import logging
+import sys
+
+from functools import wraps
+
+from .configuration import WorkspaceConfig
+from .configuration.classic import save_config
+from .configuration.discovery import load_cwd_workspace_config
+from .exceptions import RemoteError
+from .workspace import SyncedWorkspace
+
+BASE_LOGGING_FORMAT = "%(message)s"
+
+
+def log_exceptions(f):
+    """A decorator that prints the custom exceptions and exit, but propagates internal ones"""
+
+    @wraps(f)
+    def wrapper(*args, **kwards):
+        try:
+            f(*args, **kwards)
+        except Exception as e:
+            if isinstance(e, RemoteError):
+                print(str(e))
+                sys.exit(1)
+            raise
+
+    return wrapper
+
+
+def _add_remote_host(config: WorkspaceConfig, connection: str):
+    """Add a new remote host to the workspace config, check the connection, and save it if connection is ok
+
+    :param config: the workspace config decription object
+    :param connection: connection string in format of 'host-name[:remote_dir]'
+    """
+    parts = connection.split(":")
+    if len(parts) > 2:
+        print(f"Please use 'host-name[:remote_dir]' format for connection string")
+        sys.exit(1)
+    remote_host = parts[0]
+    remote_dir = None if len(parts) == 1 else parts[1]
+
+    added, index = config.add_remote_host(remote_host, remote_dir)
+    if not added:
+        print(f"{connection} already exists in config")
+        sys.exit(0)
+
+    # Check if we can connect to the remote host and create a directory there
+    workspace = SyncedWorkspace.from_config(config, config.root, index)
+    workspace.execute(f"mkdir -p {workspace.remote.directory}", simple=True)
+    print(f"Created remote directory at {workspace.remote.host}:{workspace.remote.directory}")
+
+    # No errors when executing the above code means we can save the config
+    save_config(config)
+
+
+@log_exceptions
+def remote_add():
+    parser = argparse.ArgumentParser(description="Add one more host for remote connection to a config file")
+    parser.add_argument(
+        "connection", metavar="host-name[:remote_dir]", type=str, help="a connection string for new remote directory"
+    )
+    args = parser.parse_args()
+
+    config = load_cwd_workspace_config()
+    _add_remote_host(config, args.connection)
+
+
+@log_exceptions
+def remote_init():
+    parser = argparse.ArgumentParser(
+        description="Initiate workspace for the remote execution in the current working directory"
+    )
+    parser.add_argument(
+        "connection", metavar="host-name[:remote_dir]", type=str, help="a connection string for new remote directory"
+    )
+    args = parser.parse_args()
+
+    config = WorkspaceConfig.empty()
+    _add_remote_host(config, args.connection)
+
+    # help out with .gitignore if we are in a git repository
+    if not (config.root / ".git").exists():
+        return
+
+    # make sure we don't keep adding to .gitignore
+    gitignore = config.root / ".gitignore"
+    if gitignore.exists():
+        for line in gitignore.read_text().splitlines():
+            if line.startswith(".remote"):
+                return
+
+    with gitignore.open("a") as f:
+        f.write("\n")
+        f.write(".remote*")
+        f.write("\n")
+
+    print("Added '.remote*' to .gitignore")
+
+
+@log_exceptions
+def remote_ignore():
+    parser = argparse.ArgumentParser(description="Add more patterns to the ignores list")
+    parser.add_argument("ignore", type=str, nargs="+", help="a pattern describing a file to ignore in rsync format")
+    args = parser.parse_args()
+
+    config = load_cwd_workspace_config()
+    config.ignores.add_ignores(args.ignore)
+    save_config(config)
+
+
+@log_exceptions
+def remote_host():
+    """Print the remote host in use and exit"""
+    workspace = SyncedWorkspace.from_cwd()
+    print(workspace.remote.host)
+
+
+@log_exceptions
+def remote_set():
+    parser = argparse.ArgumentParser(description="Set a new default remote host for the workspace")
+    parser.add_argument("index", type=int, help="an index of host in config file to use by default (strating from 1)")
+    args = parser.parse_args()
+
+    config = load_cwd_workspace_config()
+    if len(config.configurations) < args.index:
+        print(f"Index is too big ({args.index}). Only have {len(config.configurations)} hosts to choose from.")
+        sys.exit(1)
+    elif args.index < 1:
+        print(f"Index should be 1 or higher")
+        sys.exit(1)
+    # we use 0-base index internally
+    index = args.index - 1
+    config.default_configuration = index
+    save_config(config)
+
+    print(f"Remote host is set to {config.configurations[index].host}")
+
+
+@log_exceptions
+def remote():
+    parser = argparse.ArgumentParser(
+        description="Sync local workspace with remote directory and execute the command remotely"
+    )
+    parser.add_argument("-n", "--dry-run", action="store_true", help="do a dry run of a pull")
+    parser.add_argument("-m", "--mirror", action="store_true", help="mirror local files on remote host")
+    parser.add_argument("-v", "--verbose", action="store_true", help="increase verbosity")
+    parser.add_argument(
+        "-e", action="store_true", help="(deprecated) no effect in the new implementation",
+    )
+    parser.add_argument("command", type=str, nargs=argparse.REMAINDER, help="a command to execute")
+    args = parser.parse_args()
+
+    if not args.command:
+        print("Missing command")
+        sys.exit(1)
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format=BASE_LOGGING_FORMAT)
+
+    workspace = SyncedWorkspace.from_cwd()
+    workspace.push(dry_run=args.dry_run, verbose=args.verbose, mirror=args.mirror)
+    workspace.execute(args.command, dry_run=args.dry_run)
+    workspace.pull(dry_run=args.dry_run, verbose=args.verbose)
+
+
+@log_exceptions
+def remote_quick():
+    """Execute the command remotely"""
+    workspace = SyncedWorkspace.from_cwd()
+    workspace.execute(sys.argv[1:])
+
+
+@log_exceptions
+def remote_pull():
+    parser = argparse.ArgumentParser(description="Bring in files from remote directory to local workspace")
+    parser.add_argument("-n", "--dry-run", action="store_true", help="do a dry run of a pull")
+    parser.add_argument("-v", "--verbose", action="store_true", help="increase verbosity")
+    parser.add_argument(
+        "path", type=str, nargs="?", default=None, help="a relative path of file or directory to bring back"
+    )
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format=BASE_LOGGING_FORMAT)
+
+    workspace = SyncedWorkspace.from_cwd()
+    workspace.pull(info=True, verbose=args.verbose, dry_run=args.dry_run, subpath=args.path)
+
+
+@log_exceptions
+def remote_push(mass=False):
+    parser = argparse.ArgumentParser(description="Push local files to remote directory")
+    parser.add_argument("-n", "--dry-run", action="store_true", help="do a dry run of a pull")
+    parser.add_argument("-m", "--mirror", action="store_true", help="mirror local files on remote host")
+    parser.add_argument("-v", "--verbose", action="store_true", help="increase verbosity")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO, format=BASE_LOGGING_FORMAT)
+
+    workspaces = SyncedWorkspace.from_cwd_mass() if mass else [SyncedWorkspace.from_cwd()]
+    for workspace in workspaces:
+        workspace.push(info=True, verbose=args.verbose, dry_run=args.dry_run, mirror=args.mirror)
+
+
+@log_exceptions
+def mremote_push():
+    """Same as remote_push, but will push files to all possible remote locations configured for workspace"""
+    remote_push(mass=True)
+
+
+@log_exceptions
+def remote_delete():
+    """Delete remote directory"""
+    workspace = SyncedWorkspace.from_cwd()
+    workspace.clear_remote()
+    print(f"Successfully deleted {workspace.remote.directory} on host {workspace.remote.host}")
+
+
+@log_exceptions
+def remote_explain():
+    print("Sorry, remote-explain is not yet implemented in the new version of Remote.")
+    print("Please use the old one if you need it")
+    sys.exit(1)
+
+
+@log_exceptions
+def mremote():
+    print("Sorry, mremote is not yet implemented in the new version of Remote.")
+    print("Please use the old one if you need it")
+    sys.exit(1)

--- a/src/remote/exceptions.py
+++ b/src/remote/exceptions.py
@@ -1,0 +1,14 @@
+class RemoteError(Exception):
+    """A base class for all remote's custom exception"""
+
+
+class RemoteConnectionError(RemoteError):
+    """Remote wasn't able to connect to remote host"""
+
+
+class RemoteExecutionError(RemoteError):
+    """A command executed remotely exited with non-zero status"""
+
+
+class ConfigurationError(RemoteError):
+    """The workspace configuration is incorrect"""

--- a/src/remote/util.py
+++ b/src/remote/util.py
@@ -1,0 +1,79 @@
+import logging
+import subprocess
+import sys
+import tempfile
+import time
+
+from pathlib import Path
+from typing import List
+
+from .exceptions import RemoteConnectionError
+
+logger = logging.getLogger(__name__)
+
+
+def _temp_file(lines: List[str]) -> Path:
+    """Create a temporary file with provided content and return its path
+
+    :param lines: list of lines to be written in the file
+    """
+    tmpfile = Path(tempfile.mktemp(prefix="remote.", dir="/tmp"))
+    tmpfile.write_text("\n".join(lines) + "\n")
+
+    return tmpfile
+
+
+def rsync(
+    src: str,
+    dst: str,
+    info=False,
+    verbose=False,
+    dry_run=False,
+    mirror=False,
+    excludes=None,
+    includes=None,
+    extra_args=None,
+):
+    """Run rsync to sync files from src into dst"""
+
+    logger.info("Sync files from %s to %s", src, dst)
+    args = ["rsync", "-rlpmchz", "--copy-unsafe-links", "-e", "ssh -q", "--force"]
+    if info:
+        args.append("-i")
+    if verbose:
+        args.append("-v")
+    if dry_run:
+        args.append("-n")
+    if mirror:
+        args.extend(("--delete", "--delete-after", "--delete-excluded"))
+    if extra_args:
+        args.extend(extra_args)
+    cleanup = []
+    if excludes:
+        exclude_file = _temp_file(excludes)
+        cleanup.append(exclude_file)
+        args.extend(("--exclude-from", str(exclude_file)))
+        logger.info("Excluded patterns:")
+        for p in excludes:
+            logger.info("  - %s", p)
+    if includes:
+        include_file = _temp_file(includes)
+        cleanup.append(include_file)
+        args.extend(("--include-from", str(include_file)))
+        logger.info("Included patterns:")
+        for p in excludes:
+            logger.info("  - %s", p)
+
+    args.extend((src, dst))
+
+    logger.info("Starting sync with command %s", " ".join(args))
+    start = time.time()
+    try:
+        result = subprocess.run(args, stdout=sys.stdout, stderr=sys.stderr)
+        if result.returncode != 0:
+            raise RemoteConnectionError(f"Failed to sync files betwen {src} and {dst}. Is remote host reachable")
+    finally:
+        for file in cleanup:
+            file.unlink()
+        runtime = time.time() - start
+    logger.info("Sync done in %.2f seconds", runtime)

--- a/src/remote/workspace.py
+++ b/src/remote/workspace.py
@@ -1,0 +1,162 @@
+import logging
+import subprocess
+import sys
+import time
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Sequence, Union
+
+from .configuration import RemoteConfig, SyncIgnores, WorkspaceConfig
+from .configuration.discovery import load_cwd_workspace_config
+from .exceptions import RemoteConnectionError, RemoteExecutionError
+from .util import rsync
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SyncedWorkspace:
+    """A configured remote execution workspace"""
+
+    # absolute path to the root of the local project
+    local_root: Path
+    # information about the remote host to use
+    remote: RemoteConfig
+    # remote directory to use as working directory, relative to users home directory
+    remote_working_dir: Path
+    # sync ignore file patterns
+    ignores: SyncIgnores
+
+    @classmethod
+    def from_config(
+        cls, config: WorkspaceConfig, working_dir: Path, config_num: Optional[int] = None
+    ) -> "SyncedWorkspace":
+        """Create a workspace from configuration object
+
+        :param config: workspace config
+        :param working_dir: a working directory inside the workspace config
+        :param config_num: if present, overrides the default remote host to use
+        """
+        working_dir = working_dir.relative_to(config.root)
+        if config_num is None:
+            config_num = config.default_configuration
+        remote_config = config.configurations[config_num]
+        remote_working_dir = remote_config.directory / working_dir
+
+        return cls(
+            local_root=config.root, remote=remote_config, remote_working_dir=remote_working_dir, ignores=config.ignores,
+        )
+
+    @classmethod
+    def from_cwd(cls) -> "SyncedWorkspace":
+        """Load a workspace from current working directory of user"""
+        config = load_cwd_workspace_config()
+        return cls.from_config(config, Path.cwd())
+
+    @classmethod
+    def from_cwd_mass(cls) -> List["SyncedWorkspace"]:
+        """Load all possible workspaces from current working directory of user"""
+        config = load_cwd_workspace_config()
+
+        workspaces = []
+        for i in range(len(config.configurations)):
+            workspaces.append(cls.from_config(config, Path.cwd(), i))
+
+        return workspaces
+
+    @staticmethod
+    def _prepare_command(command: Sequence[str]) -> str:
+        # This means the whole command is already preformatted for us
+        if len(command) == 1 and " " in command[0]:
+            return command[0]
+
+        result = []
+        for item in command:
+            if not item:
+                continue
+            if " " in item:
+                result.append(f"'{item}'")
+            else:
+                result.append(item)
+
+        return " ".join(result)
+
+    def _generate_command(self, command: str) -> str:
+        return f"""\
+if [ -f {self.remote.directory}/.remoteenv ]; then
+  source {self.remote.directory}/.remoteenv 2>/dev/null 1>/dev/null
+fi
+cd {self.remote_working_dir}
+{command}
+"""
+
+    def execute(self, command: Union[str, List[str]], simple=False, dry_run=False):
+        """Execute a command remotely using ssh
+
+        :param command: a command to be executed or its parts
+        :param simple: True if command don't need to be preformatted and wrapped before execution.
+                       commands with simple will be executed from user's remote home directory
+        :param dry_run: log the command to be executed but don't run it
+        """
+        if isinstance(command, list):
+            command = self._prepare_command(command)
+        if not simple:
+            command = self._generate_command(command)
+
+        subprocess_command = ["ssh", "-tKq", self.remote.host, command]
+        logger.info("Executing:\n%s %s %s <<EOS\n%sEOS", *subprocess_command)
+        if dry_run:
+            return
+
+        start = time.time()
+        result = subprocess.run(subprocess_command, stdout=sys.stdout, stderr=sys.stderr, stdin=sys.stdin)
+        runtime = time.time() - start
+        logger.info("Execution done in %.2f seconds", runtime)
+        # ssh exits with the exit status of the remote command or with 255 if an error occurred
+        if result.returncode == 255:
+            raise RemoteConnectionError(f"Failed to connect to {self.remote.host}")
+        elif result.returncode != 0:
+            raise RemoteExecutionError(
+                f'Failed to execute "{command}" on host {self.remote.host} ({result.returncode})'
+            )
+
+    def push(self, info=False, verbose=False, dry_run=False, mirror=False):
+        """Push local workspace files to remote directory
+
+        :param info: use info logging when running rsync
+        :param verbose: use verbose logging when running rsync
+        :param dry_run: use dry_run parameter when running rsync
+        :param mirror: mirror local files remotely. It will remove ALL the remote files in the directory
+                       that weren't synced from local workspace
+        """
+        src = f"{self.local_root}/"
+        dst = f"{self.remote.host}:{self.remote.directory}"
+        ignores = self.ignores.compile_push_ignores()
+        rsync(src, dst, info=info, verbose=verbose, dry_run=dry_run, mirror=mirror, excludes=ignores)
+
+    def pull(self, info=False, verbose=False, dry_run=False, subpath=None):
+        """Pull remote files to local workspace
+
+        :param info: use info logging when running rsync
+        :param verbose: use verbose logging when running rsync
+        :param dry_run: use dry_run parameter when running rsync
+        :param subpath: a specific path to bring in. If provided, subpath will be synced
+                        even if it is ignored by workspace rules
+        """
+        if subpath is not None:
+            src = f"{self.remote.host}:{self.remote.directory}/{subpath}"
+            dst = str(self.local_root / subpath)
+            rsync(src, dst, info=info, verbose=verbose, dry_run=dry_run)
+            return
+
+        src = f"{self.remote.host}:{self.remote.directory}/"
+        dst = str(self.local_root)
+        ignores = self.ignores.compile_pull_ignores()
+        # TODO: figure out why it was used in shell version
+        # extra_args = ["--include='*/'", "--exclude='*'"]
+        rsync(src, dst, info=info, verbose=verbose, dry_run=dry_run, excludes=ignores)
+
+    def clear_remote(self):
+        """Remove remote directory"""
+        self.execute(f"rm -rf {self.remote.directory}", simple=True)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,5 @@
+flake8
+mypy
+isort
+black
+pytest


### PR DESCRIPTION
This PR adds a pythonic project layout and implements most of CLI entry points in python. It also adds the LICENSE file (BSD2).
mremote and remote-explain are not implemented due to their complexity, I'll add them separately later.

Testing done: I manually checked that all entry points work. Will add tests in the following PRs.